### PR TITLE
Wire up InferGPT frontend and backend

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,8 +1,21 @@
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from director import question
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
+
+origins = [
+    "http://localhost:8650",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/health")
 async def health_check():

--- a/backend/director.py
+++ b/backend/director.py
@@ -2,13 +2,9 @@ from utils.llm import call_model
 
 system_prompt= """
 You are a Chat Bot called InferGPT.
-
 You're abilities include:
-
 - Setting and tracking Goals
 - Remembering conversation information from previous sessions and using it in future discussions
-
-Introduce yourself if asked.
 """
 
 def question(question):

--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -5,6 +5,14 @@ export interface Response {
 export const getResponse = async (message: string): Promise<Response> => {
   // TODO - get response from backend API using env variable for endpoint
   // (.env variables available via process.env)
+  // const response = await fetch(`${process.env.BACKEND_ENDPOINT}/chat?utterance=${message}`, {
+  //   method: 'GET',
+  //   headers: {
+  //     'Content-Type': 'application/json',
+  //   },
+  // });
+  const response = await fetch('http://127.0.0.1:8000/health');
+  console.log('HELLO - response: ', response.json());
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve({ message });

--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -2,53 +2,49 @@ export interface ChatMessageResponse {
   message: string;
 }
 
-let happyResponse: ChatMessageResponse = {
-    message: "InferGPT backend is healthy!"
-}
+const happyResponse: ChatMessageResponse = {
+  message: 'InferGPT backend is healthy!'
+};
 
-let unhappyResponse: ChatMessageResponse = {
-    message: "Error: InferGPT backend is unhealthy"
-}
-
-let unsupportedResponse: ChatMessageResponse = {
-    message: "Error: General chat response unsupported"
-}
+const unhappyResponse: ChatMessageResponse = {
+  message: 'Error: InferGPT backend is unhealthy'
+};
 
 export const getResponse = async (message: string): Promise<ChatMessageResponse> => {
-    if (message == "healthcheck") {
-        return checkBackendHealth();
-    } else {
-        return callChatEndpoint(message);
-    }
+  if (message == 'healthcheck') {
+    return checkBackendHealth();
+  } else {
+    return callChatEndpoint(message);
+  }
 };
 
 const checkBackendHealth = async (): Promise<ChatMessageResponse> => {
-    try {
-        const response = await fetch(`${process.env.BACKEND_ENDPOINT}/health`);
-        console.log('InferGPT backend is healthy!: ', response);
-        return happyResponse;
-    } catch {
-        return unhappyResponse;
-    }
-}
+  try {
+    const response = await fetch(`${process.env.BACKEND_ENDPOINT}/health`);
+    console.log('InferGPT backend is healthy!: ', response);
+    return happyResponse;
+  } catch {
+    return unhappyResponse;
+  }
+};
 
 const callChatEndpoint = async (message: string): Promise<ChatMessageResponse> => {
-    return await fetch(`${process.env.BACKEND_ENDPOINT}/chat?utterance=${message}`)
-        .then(response => {
-            if (!response.ok) {
-                throw new Error(`HTTP error! Status: ${response.status}`);
-            }
-            return response;
-        })
-        .then(response => response.json())
-        .then(responseJson => {
-            let responseAsChatMessageResponse: ChatMessageResponse = {
-                message: responseJson
-            }
-            return responseAsChatMessageResponse
-        })
-        .catch(error => {
-            console.error('Error making REST call to /chat: ', error);
-            return unhappyResponse;
-        });
-}
+  return await fetch(`${process.env.BACKEND_ENDPOINT}/chat?utterance=${message}`)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      return response;
+    })
+    .then(response => response.json())
+    .then(responseJson => {
+      const responseAsChatMessageResponse: ChatMessageResponse = {
+        message: responseJson
+      };
+      return responseAsChatMessageResponse;
+    })
+    .catch(error => {
+      console.error('Error making REST call to /chat: ', error);
+      return unhappyResponse;
+    });
+};

--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -11,11 +11,11 @@ export const getResponse = async (message: string): Promise<Response> => {
   //     'Content-Type': 'application/json',
   //   },
   // });
-  const response = await fetch('http://127.0.0.1:8000/health');
+  const response = await fetch(`${process.env.BACKEND_ENDPOINT}/health`);
   console.log('HELLO - response: ', response.json());
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve({ message });
-    }, 3000);
+    }, 1000);
   });
 };

--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -2,20 +2,34 @@ export interface Response {
   message: string;
 }
 
+let happyResponse: Response = {
+    message: "InferGPT backend is healthy!"
+}
+
+let unhappyResponse: Response = {
+    message: "Error: InferGPT backend is unhealthy"
+}
+
+let unsupportedResponse: Response = {
+    message: "Error: General chat response unsupported"
+}
+
 export const getResponse = async (message: string): Promise<Response> => {
-  // TODO - get response from backend API using env variable for endpoint
-  // (.env variables available via process.env)
-  // const response = await fetch(`${process.env.BACKEND_ENDPOINT}/chat?utterance=${message}`, {
-  //   method: 'GET',
-  //   headers: {
-  //     'Content-Type': 'application/json',
-  //   },
-  // });
-  const response = await fetch(`${process.env.BACKEND_ENDPOINT}/health`);
-  console.log('HELLO - response: ', response.json());
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ message });
-    }, 1000);
-  });
+    if (message == "healthcheck") {
+        try {
+            const response = await fetch(`${process.env.BACKEND_ENDPOINT}/health`);
+            console.log('InferGPT backend is healthy!: ', response.json());
+            return new Promise((resolve) => {
+                setTimeout(() => {resolve(happyResponse);}, 1000);
+            });
+        } catch {
+            return new Promise((resolve) => {
+                setTimeout(() => {resolve(unhappyResponse);}, 1000);
+            })
+        }
+    } else {
+        return new Promise((resolve) => {
+            setTimeout(() => {resolve(unsupportedResponse);}, 1000);
+        })
+    }
 };


### PR DESCRIPTION
## Description
Connects the backend /chat and /health endpoints to the frontend. The /health endpoint can be accessed by sending the message "healthcheck" to InferGPT. You will either receive a "InferGPT backend is healthy!" or "Error: InferGPT backend is unhealthy" in response.

![healthcheck_keyword_demo](https://github.com/WaitThatShouldntWork/InferGPT/assets/48159708/2c0899e8-f203-4bdd-a4c2-29434c1d29d0)

All other messages go to the LLM for a generated response

![hello_infergpt](https://github.com/WaitThatShouldntWork/InferGPT/assets/48159708/b9931fad-3250-4d84-95e7-6d267a64de13)

## Changelog
- Changed `server.ts` to call the backend on port `8250`
- Added a check for if the user submitted the string "healthcheck". If so, the `/health` endpoint is called
- Allowed CORS requests (as both services are currently running on the same machine)
- Tweaked the system prompt to avoid the service continually regurgitating it's initial hello statement
