### PR TITLE
Add backend test framework

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,22 +2,32 @@
 
 Python service for the InferGPT backend.
 
-### Subdirectories
+## Structure
 - `/supervisors` storing all supervisor modules (agents that call other agents for a greater goal)
 - `/agents` containing all agents the director can call. Agents have their own functions stored within the agent module
 - `/utils` with all shared utility modules
 - `/tools` for all shared function modules
 
-### Set up
-- To install all project dependencies (listed in `requirements.txt`) run `pip install -r requirements.txt`.
-- Once all dependencies have been pulled run `uvicorn api:app --port 8250` to start the app. 
-- Check the backend app is running at [http://127.0.0.1:8250/health](http://127.0.0.1:8250/health).
+## Set up
+
+Unless otherwise stated all of the commands mentioned in this README should be run from this directory.
+
+1. Install dependencies
+```bash
+pip install -r requirements.txt
+```
+2. Run the app
+```bash
+uvicorn api:app --port 8250
+```
+
+3. Check the backend app is running at [http://127.0.0.1:8250/health](http://127.0.0.1:8250/health)
 
 ## Backend Linting
 
 Ruff is being used for the backend linting. See the docs: [here](https://docs.astral.sh/ruff/)
 
-Make sure the ruff dependency is downloaded, it should have been included in `requirements.txt`.
+Make sure the ruff dependency is downloaded, it is in `requirements.txt` so step `1` of [setup](#set-up) should do this for you.
 
 Run the following command to check:
 
@@ -25,7 +35,7 @@ Run the following command to check:
 ruff --version
 ```
 
-If it is not installed use the follwoing command:
+If it is not installed use the following command:
 
 ```bash
 pip install ruff
@@ -37,6 +47,12 @@ If ruff is installed correctly, the python files in the backend will be checked 
 ruff check
 ```
 
+You can run the following from the backend directory to attempt to fix any errors automatically:
+
+```bash
+ruff format
+```
+
 The ruff vscode plugin can also be installed from the store to show linting errors in the IDE.
 
 ### Linting Rules
@@ -44,3 +60,13 @@ The ruff vscode plugin can also be installed from the store to show linting erro
 Currently there are 4 rule groups selected in`ruff.toml`. All rule groups can be found [here](https://docs.astral.sh/ruff/rules/).
 
 To add further rules, these are added to `ruff.toml` by using the letter asssigned to the rules as in the docs linked above. ie. pep8-naming uses the letter "N".
+
+## Test
+
+`pytest` is being used for testing the backend. Like with linting running the [setup](#set-up) steps should download `pytest` for you. To then run the tests, use the following command:
+
+```bash
+pytest
+```
+
+More documentation on `pytest` can be found [here](https://docs.pytest.org/en/8.0.x/).

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,7 +10,7 @@ Python service for the InferGPT backend.
 
 ## Set up
 
-Unless otherwise stated all of the commands mentioned in this README should be run from this directory.
+Unless otherwise stated all of the commands mentioned in this README should be run from `./backend`.
 
 1. Install dependencies
 ```bash
@@ -47,7 +47,7 @@ If ruff is installed correctly, the python files in the backend will be checked 
 ruff check
 ```
 
-You can run the following from the backend directory to attempt to fix any errors automatically:
+You can run the following command to fix any errors automatically:
 
 ```bash
 ruff format
@@ -63,7 +63,7 @@ To add further rules, these are added to `ruff.toml` by using the letter asssign
 
 ## Test
 
-`pytest` is being used for testing the backend. Like with linting running the [setup](#set-up) steps should download `pytest` for you. To then run the tests, use the following command:
+`pytest` is being used for testing the backend. Like with linting, running the [setup](#set-up) steps should download `pytest` for you. To then run the tests, use the following command:
 
 ```bash
 pytest

--- a/backend/api.py
+++ b/backend/api.py
@@ -25,6 +25,7 @@ app.add_middleware(
 healthy_response = {"message": "InferGPT backend is healthy"}
 error_message = "Unable to formulate InferGPT response"
 
+
 @app.get("/health")
 async def health_check():
     logger.info("health_check method called successfully")

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,4 +1,5 @@
 import logging
+import logging.config
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -21,11 +22,13 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+healthy_response = {"message": "InferGPT backend is healthy"}
+error_message = "Unable to formulate InferGPT response"
 
 @app.get("/health")
 async def health_check():
     logger.info("health_check method called successfully")
-    return {"message": "InferGPT backend is healthy"}
+    return healthy_response
 
 
 @app.get("/chat")
@@ -35,6 +38,4 @@ async def chat(utterance: str):
         return JSONResponse(status_code=200, content=question(utterance))
     except Exception as e:
         logger.exception(e)
-        return JSONResponse(
-            status_code=500, content="Unable to formulate InferGPT response"
-        )
+        return JSONResponse(status_code=500, content=error_message)

--- a/backend/api_test.py
+++ b/backend/api_test.py
@@ -4,15 +4,17 @@ from api import app, healthy_response, error_message
 client = TestClient(app)
 utterance = "Hello there"
 
+
 def test_health_check_response():
     response = client.get("/health")
 
     assert response.status_code == 200
     assert response.json() == healthy_response
 
+
 def test_chat_success_response(mocker):
-    expected_message = 'InferGPT backend is healthy'
-    mock_question = mocker.patch('api.question', return_value=expected_message)
+    expected_message = "InferGPT backend is healthy"
+    mock_question = mocker.patch("api.question", return_value=expected_message)
 
     response = client.get(f"/chat?utterance={utterance}")
 
@@ -20,10 +22,11 @@ def test_chat_success_response(mocker):
     assert response.status_code == 200
     assert response.json() == expected_message
 
+
 def test_chat_failure_response(mocker):
-    expected_message = 'InferGPT backend is healthy'
-    mock_question = mocker.patch('api.question', return_value=expected_message)
-    mock_question.side_effect = Exception('An error occurred')
+    expected_message = "InferGPT backend is healthy"
+    mock_question = mocker.patch("api.question", return_value=expected_message)
+    mock_question.side_effect = Exception("An error occurred")
 
     response = client.get(f"/chat?utterance={utterance}")
 

--- a/backend/api_test.py
+++ b/backend/api_test.py
@@ -1,0 +1,32 @@
+from fastapi.testclient import TestClient
+from api import app, healthy_response, error_message
+
+client = TestClient(app)
+utterance = "Hello there"
+
+def test_health_check_response():
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == healthy_response
+
+def test_chat_success_response(mocker):
+    expected_message = 'InferGPT backend is healthy'
+    mock_question = mocker.patch('api.question', return_value=expected_message)
+
+    response = client.get(f"/chat?utterance={utterance}")
+
+    mock_question.assert_called_with(utterance)
+    assert response.status_code == 200
+    assert response.json() == expected_message
+
+def test_chat_failure_response(mocker):
+    expected_message = 'InferGPT backend is healthy'
+    mock_question = mocker.patch('api.question', return_value=expected_message)
+    mock_question.side_effect = Exception('An error occurred')
+
+    response = client.get(f"/chat?utterance={utterance}")
+
+    mock_question.assert_called_with(utterance)
+    assert response.status_code == 500
+    assert response.json() == error_message

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ pycodestyle==2.11.1
 python-dotenv==1.0.1
 neo4j==5.18.0
 ruff==0.3.5
+pytest==8.1.1
+pytest-mock==3.14.0

--- a/backend/utils/llm_test.py
+++ b/backend/utils/llm_test.py
@@ -10,45 +10,46 @@ system_prompt = "system_prompt"
 user_prompt = "user_prompt"
 content_response = "Hello there"
 
+
 def create_mock_chat_response(content, tool_calls=None):
     mock_usage = UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=3)
     mock_message = ChatMessage(role="system", content=content, tool_calls=tool_calls)
     mock_choice = ChatCompletionResponseChoice(index=0, message=mock_message, finish_reason=None)
     return ChatCompletionResponse(
-        id="id",
-        object="object",
-        created=123,
-        model="model",
-        choices=[mock_choice],
-        usage=mock_usage
+        id="id", object="object", created=123, model="model", choices=[mock_choice], usage=mock_usage
     )
+
 
 mock_client = MagicMock(spec=MistralClient)
 mock_config = MagicMock(spec=Config)
 
+
 def test_call_model_returns_string(mocker):
-    client_instance = mocker.patch('utils.llm.client', return_value=mock_client)
+    client_instance = mocker.patch("utils.llm.client", return_value=mock_client)
     client_instance.chat.return_value = create_mock_chat_response(content_response)
 
     response = call_model(system_prompt, user_prompt)
 
     assert response == content_response
 
+
 def test_call_model_calls_client_chat(mocker):
-    config_instance = mocker.patch('utils.llm.config', return_value=mock_config)
-    client_instance = mocker.patch('utils.llm.client', return_value=mock_client)
+    config_instance = mocker.patch("utils.llm.config", return_value=mock_config)
+    client_instance = mocker.patch("utils.llm.client", return_value=mock_client)
 
     call_model(system_prompt, user_prompt)
 
-    expected_messages = [ChatMessage(role="system", content=system_prompt), ChatMessage(role="user", content=user_prompt)]
+    expected_messages = [
+        ChatMessage(role="system", content=system_prompt),
+        ChatMessage(role="user", content=user_prompt),
+    ]
     client_instance.chat.assert_called_once_with(
-        messages=expected_messages,
-        model=config_instance.mistral_model,
-        tool_choice=None,
-        tools=None
+        messages=expected_messages, model=config_instance.mistral_model, tool_choice=None, tools=None
     )
 
-tools = [{
+
+tools = [
+    {
         "type": "function",
         "function": {
             "description": "mock tool",
@@ -64,39 +65,33 @@ tools = [{
                 "required": ["name"],
             },
         },
-    }]
-
-tool_calls = [{
-    "id": "1",
-    "type": "function",
-    "function": {
-        "name": "mock_tool",
-        "arguments": '{ "name": "Bob" }'
     }
-}]
+]
+
+tool_calls = [{"id": "1", "type": "function", "function": {"name": "mock_tool", "arguments": '{ "name": "Bob" }'}}]
+
 
 def test_call_model_with_tools_returns_tuple(mocker):
-    client_instance = mocker.patch('utils.llm.client', return_value=mock_client)
+    client_instance = mocker.patch("utils.llm.client", return_value=mock_client)
     client_instance.chat.return_value = create_mock_chat_response(content_response, tool_calls=tool_calls)
 
     (name, params) = call_model_with_tools(system_prompt, user_prompt, tools)
 
     assert name == "mock_tool"
-    assert params == { "name": "Bob" }
-    
-    
+    assert params == {"name": "Bob"}
+
 
 def test_call_model_with_tools_calls_client_chat(mocker):
-    client_instance = mocker.patch('utils.llm.client', return_value=mock_client)
+    client_instance = mocker.patch("utils.llm.client", return_value=mock_client)
     client_instance.chat.return_value = create_mock_chat_response(content_response, tool_calls=tool_calls)
-    config_instance = mocker.patch('utils.llm.config', return_value=mock_config)
+    config_instance = mocker.patch("utils.llm.config", return_value=mock_config)
 
     call_model_with_tools(system_prompt, user_prompt, tools)
 
-    expected_messages = [ChatMessage(role="system", content=system_prompt), ChatMessage(role="user", content=user_prompt)]
+    expected_messages = [
+        ChatMessage(role="system", content=system_prompt),
+        ChatMessage(role="user", content=user_prompt),
+    ]
     client_instance.chat.assert_called_once_with(
-        messages=expected_messages,
-        model=config_instance.mistral_model,
-        tool_choice="any",
-        tools=tools
+        messages=expected_messages, model=config_instance.mistral_model, tool_choice="any", tools=tools
     )

--- a/backend/utils/llm_test.py
+++ b/backend/utils/llm_test.py
@@ -1,0 +1,102 @@
+from utils.llm import call_model, call_model_with_tools, MistralClient
+from unittest.mock import MagicMock
+from mistralai.models.chat_completion import ChatCompletionResponse
+from mistralai.models.chat_completion import ChatCompletionResponseChoice
+from mistralai.models.chat_completion import ChatMessage
+from mistralai.models.common import UsageInfo
+from utils import Config
+
+system_prompt = "system_prompt"
+user_prompt = "user_prompt"
+content_response = "Hello there"
+
+def create_mock_chat_response(content, tool_calls=None):
+    mock_usage = UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=3)
+    mock_message = ChatMessage(role="system", content=content, tool_calls=tool_calls)
+    mock_choice = ChatCompletionResponseChoice(index=0, message=mock_message, finish_reason=None)
+    return ChatCompletionResponse(
+        id="id",
+        object="object",
+        created=123,
+        model="model",
+        choices=[mock_choice],
+        usage=mock_usage
+    )
+
+mock_client = MagicMock(spec=MistralClient)
+mock_config = MagicMock(spec=Config)
+
+def test_call_model_returns_string(mocker):
+    client_instance = mocker.patch('utils.llm.client', return_value=mock_client)
+    client_instance.chat.return_value = create_mock_chat_response(content_response)
+
+    response = call_model(system_prompt, user_prompt)
+
+    assert response == content_response
+
+def test_call_model_calls_client_chat(mocker):
+    config_instance = mocker.patch('utils.llm.config', return_value=mock_config)
+    client_instance = mocker.patch('utils.llm.client', return_value=mock_client)
+
+    call_model(system_prompt, user_prompt)
+
+    expected_messages = [ChatMessage(role="system", content=system_prompt), ChatMessage(role="user", content=user_prompt)]
+    client_instance.chat.assert_called_once_with(
+        messages=expected_messages,
+        model=config_instance.mistral_model,
+        tool_choice=None,
+        tools=None
+    )
+
+tools = [{
+        "type": "function",
+        "function": {
+            "description": "mock tool",
+            "name": "mock_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "A name.",
+                    },
+                },
+                "required": ["name"],
+            },
+        },
+    }]
+
+tool_calls = [{
+    "id": "1",
+    "type": "function",
+    "function": {
+        "name": "mock_tool",
+        "arguments": '{ "name": "Bob" }'
+    }
+}]
+
+def test_call_model_with_tools_returns_tuple(mocker):
+    client_instance = mocker.patch('utils.llm.client', return_value=mock_client)
+    client_instance.chat.return_value = create_mock_chat_response(content_response, tool_calls=tool_calls)
+
+    (name, params) = call_model_with_tools(system_prompt, user_prompt, tools)
+
+    assert name == "mock_tool"
+    assert params == { "name": "Bob" }
+    
+    
+
+def test_call_model_with_tools_calls_client_chat(mocker):
+    client_instance = mocker.patch('utils.llm.client', return_value=mock_client)
+    client_instance.chat.return_value = create_mock_chat_response(content_response, tool_calls=tool_calls)
+    config_instance = mocker.patch('utils.llm.config', return_value=mock_config)
+
+    call_model_with_tools(system_prompt, user_prompt, tools)
+
+    expected_messages = [ChatMessage(role="system", content=system_prompt), ChatMessage(role="user", content=user_prompt)]
+    client_instance.chat.assert_called_once_with(
+        messages=expected_messages,
+        model=config_instance.mistral_model,
+        tool_choice="any",
+        tools=tools
+    )


### PR DESCRIPTION
## Description

This PR adds `pytest` and `pytest-mock` to our backend, allowing us to write unit tests

## Changelog
-  add `pytest` and `pytest-mock` to requirements file
- add basic tests for `api.py`
- add basic tests for `llm.py`
- update readme on how to run tests
