### PR TITLE
Create unit tests for Graph DB Utils

### DIFF
--- a/backend/utils/graph_db_utils_test.py
+++ b/backend/utils/graph_db_utils_test.py
@@ -1,0 +1,52 @@
+from unittest.mock import ANY, MagicMock
+from neo4j import Driver, Session
+import pytest
+import utils.graph_db_utils
+
+def test_database_connectivity_is_healthy(mocker):
+    mock_driver = mocker.patch("utils.graph_db_utils.driver", return_value=MagicMock(spec=Driver))
+    mock_driver.verify_connectivity.return_value = None
+
+    connected = utils.graph_db_utils.test_connection()
+
+    assert connected
+    mock_driver.verify_connectivity.assert_called_once()
+    mock_driver.close.assert_called_once()
+
+
+def test_database_connectivity_is_unhealthy(mocker):
+    mock_driver = mocker.patch("utils.graph_db_utils.driver", return_value=MagicMock(spec=Driver))
+    mock_driver.verify_connectivity.side_effect = Exception
+
+    connected = utils.graph_db_utils.test_connection()
+
+    assert not connected
+    mock_driver.verify_connectivity.assert_called_once()
+    mock_driver.close.assert_called_once()
+
+
+def test_create_goal_is_successful(mocker):
+    mock_driver = mocker.patch("utils.graph_db_utils.driver", return_value=MagicMock(spec=Driver))
+    mock_session = MagicMock(spec=Session)
+    mock_driver.session.return_value = mock_session
+
+    response = utils.graph_db_utils.create_goal("Test Name", "Test Description")
+
+    assert response is None
+    mock_session.run.assert_called_once_with(ANY, name="Test Name", description="Test Description")
+    mock_session.close.assert_called_once()
+    mock_driver.close.assert_called_once()
+
+
+def test_create_goal_throws_exception(mocker):
+    mock_driver = mocker.patch("utils.graph_db_utils.driver", return_value=MagicMock(spec=Driver))
+    mock_session = MagicMock(spec=Session)
+    mock_driver.session.return_value = mock_session
+    mock_session.run.side_effect = Exception
+
+    with pytest.raises(Exception):
+        utils.graph_db_utils.create_goal("Test Name", "Test Description")
+
+    mock_session.run.assert_called_once_with(ANY, name="Test Name", description="Test Description")
+    mock_session.close.assert_called_once()
+    mock_driver.close.assert_called_once()

--- a/backend/utils/graph_db_utils_test.py
+++ b/backend/utils/graph_db_utils_test.py
@@ -18,8 +18,8 @@ def mock_driver(mocker, mock_session):
 
 def remove_whitespace_and_newlines(original):
     return " ".join(original.replace(r'\n', ' ').replace(r'\r', '').split())
-    
-    
+
+
 def test_database_connectivity_is_healthy(mock_driver):
     mock_driver.verify_connectivity.return_value = None
 

--- a/backend/utils/graph_db_utils_test.py
+++ b/backend/utils/graph_db_utils_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 from neo4j import Driver, Session
 import pytest
 # We assign an alias to "test_connection" to avoid pytest treating it as another test function
@@ -48,7 +48,7 @@ def test_create_goal_is_successful(mock_driver, mock_session):
     assert kwargs == { "name":"Test Name", "description":"Test Description" }
     actual_cypher_query = remove_whitespace_and_newlines(str(args[0]))
     expected_cypher_query = "MERGE (g:Goal {name: $name, description: $description}) RETURN g"
-    assert expected_cypher_query == actual_cypher_query
+    assert actual_cypher_query == expected_cypher_query
     mock_session.close.assert_called_once()
     mock_driver.close.assert_called_once()
 
@@ -59,6 +59,6 @@ def test_create_goal_throws_exception(mock_driver, mock_session):
     with pytest.raises(Exception):
         create_goal("Test Name", "Test Description")
 
-    mock_session.run.assert_called_once_with(ANY, name="Test Name", description="Test Description")
+    mock_session.run.assert_called_once()
     mock_session.close.assert_called_once()
     mock_driver.close.assert_called_once()

--- a/backend/utils/graph_db_utils_test.py
+++ b/backend/utils/graph_db_utils_test.py
@@ -1,13 +1,14 @@
 from unittest.mock import ANY, MagicMock
 from neo4j import Driver, Session
 import pytest
-import utils.graph_db_utils
+# We assign an alias to "test_connection" to avoid pytest treating it as another test function
+from utils.graph_db_utils import test_connection as verify_connection, create_goal
 
 def test_database_connectivity_is_healthy(mocker):
     mock_driver = mocker.patch("utils.graph_db_utils.driver", return_value=MagicMock(spec=Driver))
     mock_driver.verify_connectivity.return_value = None
 
-    connected = utils.graph_db_utils.test_connection()
+    connected = verify_connection()
 
     assert connected
     mock_driver.verify_connectivity.assert_called_once()
@@ -18,7 +19,7 @@ def test_database_connectivity_is_unhealthy(mocker):
     mock_driver = mocker.patch("utils.graph_db_utils.driver", return_value=MagicMock(spec=Driver))
     mock_driver.verify_connectivity.side_effect = Exception
 
-    connected = utils.graph_db_utils.test_connection()
+    connected = verify_connection()
 
     assert not connected
     mock_driver.verify_connectivity.assert_called_once()
@@ -30,7 +31,7 @@ def test_create_goal_is_successful(mocker):
     mock_session = MagicMock(spec=Session)
     mock_driver.session.return_value = mock_session
 
-    response = utils.graph_db_utils.create_goal("Test Name", "Test Description")
+    response = create_goal("Test Name", "Test Description")
 
     assert response is None
     mock_session.run.assert_called_once_with(ANY, name="Test Name", description="Test Description")
@@ -45,7 +46,7 @@ def test_create_goal_throws_exception(mocker):
     mock_session.run.side_effect = Exception
 
     with pytest.raises(Exception):
-        utils.graph_db_utils.create_goal("Test Name", "Test Description")
+        create_goal("Test Name", "Test Description")
 
     mock_session.run.assert_called_once_with(ANY, name="Test Name", description="Test Description")
     mock_session.close.assert_called_once()

--- a/backend/utils/graph_db_utils_test.py
+++ b/backend/utils/graph_db_utils_test.py
@@ -16,6 +16,10 @@ def mock_driver(mocker, mock_session):
     return mock_driver
 
 
+def remove_whitespace_and_newlines(original):
+    return " ".join(original.replace(r'\n', ' ').replace(r'\r', '').split())
+    
+    
 def test_database_connectivity_is_healthy(mock_driver):
     mock_driver.verify_connectivity.return_value = None
 
@@ -41,6 +45,10 @@ def test_create_goal_is_successful(mock_driver, mock_session):
 
     assert response is None
     mock_session.run.assert_called_once_with(ANY, name="Test Name", description="Test Description")
+    args = mock_session.run.call_args
+    actual_cypher_query = remove_whitespace_and_newlines(str(args[0]))
+    expected_cypher_query = "MERGE (g:Goal {name: $name, description: $description}) RETURN g"
+    assert expected_cypher_query in actual_cypher_query
     mock_session.close.assert_called_once()
     mock_driver.close.assert_called_once()
 

--- a/backend/utils/graph_db_utils_test.py
+++ b/backend/utils/graph_db_utils_test.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 from neo4j import Driver, Session
 import pytest
 # We assign an alias to "test_connection" to avoid pytest treating it as another test function
-from utils.graph_db_utils import test_connection as verify_connection, create_goal
+from utils import test_connection as verify_connection, create_goal
 
 @pytest.fixture
 def mock_session():

--- a/backend/utils/graph_db_utils_test.py
+++ b/backend/utils/graph_db_utils_test.py
@@ -44,11 +44,11 @@ def test_create_goal_is_successful(mock_driver, mock_session):
     response = create_goal("Test Name", "Test Description")
 
     assert response is None
-    mock_session.run.assert_called_once_with(ANY, name="Test Name", description="Test Description")
-    args = mock_session.run.call_args
+    args, kwargs = mock_session.run.call_args
+    assert kwargs == { "name":"Test Name", "description":"Test Description" }
     actual_cypher_query = remove_whitespace_and_newlines(str(args[0]))
     expected_cypher_query = "MERGE (g:Goal {name: $name, description: $description}) RETURN g"
-    assert expected_cypher_query in actual_cypher_query
+    assert expected_cypher_query == actual_cypher_query
     mock_session.close.assert_called_once()
     mock_driver.close.assert_called_once()
 


### PR DESCRIPTION
## Description

This PR creates a new test for `graph_db_utils.py` that covers the `verify_connectivity()` and `create_goal()` methods.

The tests mock the neo4j `driver` and `session` to verify the expected behaviour when `graph_db_utils.py` uses these neo4j instances.

Test cover:

- Confirm  `verify_connectivity()` returns `True` when we can connect to neo4j database
- Confirm  `verify_connectivity()` returns `False` when the connection to neo4j database fails
- Confirm  `create_goal()` results in calls to the neo4j `session.run()` method to create a goal node
- Confirm  `create_goal()` throws an exception when the neo4j `session.run()` fails

## Changelog

-  Created test file `graph_db_utils_test.py`.
