### PR TITLE
plug in frontend local env file from parent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ FRONTEND_URL=http://localhost:8650
 
 # what backend URL should be used by frontend API requests
 BACKEND_URL=http://localhost:8250
+
+# websockets url to conect to backend websocket endpoint
+WS_URL=ws://localhost:8250/ws

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -1,14 +1,11 @@
 name: Test Backend
 on: 
   pull_request:
-    paths:
-      - 'backend/**'
 
 jobs:
   testing:
     name: Testing Backend
     runs-on: ubuntu-latest
-    if: github.event.pull_request.changed_files != 0
     defaults:
       run:
         working-directory: ./backend

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -8,6 +8,7 @@ jobs:
   testing:
     name: Testing Backend
     runs-on: ubuntu-latest
+    if: github.event.pull_request.changed_files != 0
     defaults:
       run:
         working-directory: ./backend

--- a/compose.yml
+++ b/compose.yml
@@ -68,6 +68,7 @@ services:
       dockerfile: ./Dockerfile
     environment:
       BACKEND_URL: ${BACKEND_URL}
+      WS_URL: ${WS_URL}
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -6,7 +6,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const env = { ...process.env, ...dotenv.config().parsed };
+const localEnv = dotenv.config({ path: path.resolve(__dirname, '../.env') }).parsed;
+const env = { ...process.env, ...localEnv }; 
 
 const config = {
   mode: 'development',


### PR DESCRIPTION
## Description

This PR fixes:
-  A local root `.env` file being used in the frontend
- passing the websocket url via docker