### PR TITLE
add llm config to example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,11 @@ WS_URL=ws://localhost:8250/ws
 AZURE_STORAGE_CONNECTION_STRING="my-connection-string"
 AZURE_STORAGE_CONTAINER_NAME=my-container-name
 AZURE_INITIAL_DATA_FILENAME=test-data.json
+
+# llm config
+ANSWER_AGENT_LLM="mistral"
+INTENT_AGENT_llm="mistral"
+VALIDATOR_AGENT_LLM="mistral"
+DATASTORE_AGENT_LLM="mistral"
+MATHS_AGENT_LLM="mistral"
+ROUTER_LLM="mistral"


### PR DESCRIPTION
## Description

Added all llm cofig variables to the example env. Put them as `mistral` which is valid, don't think we need to change it for security reasons like with some of the other env properties. Happy to be challenged on this


## Changelog
- add llm config variables to example env
