### PR TITLE
Feature/refactor backend tests env dependency

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -24,26 +24,6 @@ jobs:
           pip install -r requirements.txt
           pip install pytest-md pytest-emoji
 
-        # some tests require an .env file to run.
-        # file should contain all the required properties.  
-      - name: Create environment file
-        run: |
-          echo "Create environment file"
-          cat <<EOF > .env
-          MODEL=my-model
-          MISTRAL_KEY=123456
-          NEO4J_URI=bolt://localhost:1234
-          NEO4J_USERNAME=neo4j
-          NEO4J_PASSWORD=my-password
-          ANSWER_AGENT_LLM=mistral
-          INTENT_AGENT_LLM=mistral
-          VALIDATOR_AGENT_LLM=mistral
-          DATASTORE_AGENT_LLM=mistral
-          MATHS_AGENT_LLM=mistral
-          ROUTER_LLM=mistral
-          EOF
-          cat .env
-
       - name: Run tests
         uses: pavelzw/pytest-action@v2
         with:

--- a/backend/src/agents/__init__.py
+++ b/backend/src/agents/__init__.py
@@ -27,12 +27,12 @@ def agent_details(agent) -> dict:
     return {"name": agent.name, "description": agent.description}
 
 
-def get_question_agents() -> List[Agent]:
+def get_available_agents() -> List[Agent]:
     return [DatastoreAgent(config.datastore_agent_llm), MathsAgent(config.maths_agent_llm)]
 
 
 def get_agent_details():
-    agents = get_question_agents()
+    agents = get_available_agents()
     return [agent_details(agent) for agent in agents]
 
 
@@ -43,7 +43,7 @@ __all__ = [
     "get_agent_details",
     "get_answer_agent",
     "get_intent_agent",
-    "get_question_agents",
+    "get_available_agents",
     "get_validator_agent",
     "Parameter",
     "tool",

--- a/backend/src/agents/__init__.py
+++ b/backend/src/agents/__init__.py
@@ -1,3 +1,4 @@
+from typing import List
 from src.utils import Config
 from .agent import Agent, agent
 from .datastore_agent import DatastoreAgent
@@ -10,26 +11,40 @@ from .answer_agent import AnswerAgent
 config = Config()
 
 
-validator_agent = ValidatorAgent(config.validator_agent_llm)
-intent_agent = IntentAgent(config.intent_agent_llm)
-answer_agent = AnswerAgent(config.answer_agent_llm)
+def get_validator_agent() -> Agent:
+    return ValidatorAgent(config.validator_agent_llm)
 
 
-def get_agent_details(agent):
+def get_intent_agent() -> Agent:
+    return IntentAgent(config.intent_agent_llm)
+
+
+def get_answer_agent() -> Agent:
+    return AnswerAgent(config.answer_agent_llm)
+
+
+def agent_details(agent) -> dict:
     return {"name": agent.name, "description": agent.description}
 
 
-agents = [DatastoreAgent(config.datastore_agent_llm), MathsAgent(config.maths_agent_llm)]
-agents_details = [get_agent_details(agent) for agent in agents]
+def get_question_agents() -> List[Agent]:
+    return [DatastoreAgent(config.datastore_agent_llm), MathsAgent(config.maths_agent_llm)]
+
+
+def get_agent_details():
+    agents = get_question_agents()
+    return [agent_details(agent) for agent in agents]
+
 
 __all__ = [
     "agent",
     "Agent",
-    "agents_details",
-    "agents",
-    "answer_agent",
-    "intent_agent",
+    "agent_details",
+    "get_agent_details",
+    "get_answer_agent",
+    "get_intent_agent",
+    "get_question_agents",
+    "get_validator_agent",
     "Parameter",
     "tool",
-    "validator_agent",
 ]

--- a/backend/src/director.py
+++ b/backend/src/director.py
@@ -1,7 +1,7 @@
 import json
 import logging
-from src.utils.scratchpad import clear_scratchpad, update_scratchpad
-from src.agents import intent_agent, answer_agent
+from src.utils import clear_scratchpad, update_scratchpad
+from src.agents import get_intent_agent, get_answer_agent
 from src.prompts import PromptEngine
 from src.supervisors import solve_all
 
@@ -11,9 +11,9 @@ engine = PromptEngine()
 director_prompt = engine.load_prompt("director")
 
 
-def question(question) -> str:
+def question(question: str) -> str:
     logging.debug("Received utterance: {question}")
-    intent = intent_agent.invoke(question)
+    intent = get_intent_agent().invoke(question)
     intent_json = json.loads(intent)
     logging.info(f"Intent determined: {intent}")
 
@@ -22,7 +22,7 @@ def question(question) -> str:
     except Exception as error:
         update_scratchpad(error=str(error))
 
-    final_answer = answer_agent.invoke(question)
+    final_answer = get_answer_agent().invoke(question)
     logging.info(f"final answer: {final_answer}")
 
     clear_scratchpad()

--- a/backend/src/router.py
+++ b/backend/src/router.py
@@ -2,16 +2,14 @@ import json
 import logging
 from src.utils import to_json, Config
 from src.prompts import PromptEngine
-from src.agents import Agent, agents, agents_details
+from src.agents import Agent, get_question_agents, get_agent_details
 from src.llm import get_llm
 
 prompt_engine = PromptEngine()
 config = Config()
 
-llm = get_llm(config.router_llm)
-
-
 def build_best_next_step_prompt(task, scratchpad):
+    agents_details = get_agent_details()
     return prompt_engine.load_prompt(
         "best-next-step",
         task=json.dumps(task, indent=4),
@@ -41,10 +39,12 @@ def build_plan(task, llm, scratchpad):
 
 
 def find_agent_from_name(name):
+    agents = get_question_agents()
     return (agent for agent in agents if agent.name == name)
 
 
 def get_agent_for_task(task, scratchpad) -> Agent | None:
+    llm = get_llm(config.router_llm)
     plan = build_plan(task, llm, scratchpad)
     agent = next(find_agent_from_name(plan["agent_name"]), None)
 

--- a/backend/src/router.py
+++ b/backend/src/router.py
@@ -2,7 +2,7 @@ import json
 import logging
 from src.utils import to_json, Config
 from src.prompts import PromptEngine
-from src.agents import Agent, get_question_agents, get_agent_details
+from src.agents import Agent, get_available_agents, get_agent_details
 from src.llm import get_llm
 
 prompt_engine = PromptEngine()
@@ -39,7 +39,7 @@ def build_plan(task, llm, scratchpad):
 
 
 def find_agent_from_name(name):
-    agents = get_question_agents()
+    agents = get_available_agents()
     return (agent for agent in agents if agent.name == name)
 
 

--- a/backend/src/supervisors/supervisor.py
+++ b/backend/src/supervisors/supervisor.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 from src.utils import get_scratchpad, update_scratchpad
 from src.router import get_agent_for_task
-from src.agents import validator_agent
+from src.agents import get_validator_agent
 
 no_questions_response = "No questions found to solve"
 unsolvable_response = "I am sorry, but I was unable to find an answer to this task"
@@ -39,5 +39,5 @@ def solve_task(task, scratchpad, attempt=0) -> Tuple[str, str]:
 
 
 def is_valid_answer(answer, task) -> bool:
-    is_valid = (validator_agent.invoke(f"Task: {task}  Answer: {answer}")).lower() == "true"
+    is_valid = (get_validator_agent().invoke(f"Task: {task}  Answer: {answer}")).lower() == "true"
     return is_valid

--- a/backend/tests/router_test.py
+++ b/backend/tests/router_test.py
@@ -1,4 +1,5 @@
 import json
+from src.agents import agent_details
 from src.llm import get_llm
 from tests.agents import MockAgent, mock_agent_name
 from src.router import get_agent_for_task
@@ -13,8 +14,9 @@ scratchpad = []
 
 def test_get_agent_for_task_no_agent_found(mocker):
     plan = '{ "agent_name": "this_agent_does_not_exist" }'
-    mocker.patch("src.router.agents", mock_agents)
-    mocker.patch("src.router.llm", mock_model)
+    mocker.patch("src.router.get_llm", return_value=mock_model)
+    mocker.patch("src.router.get_question_agents", return_value=mock_agents)
+    mocker.patch("src.router.get_agent_details", return_value=[agent_details(mock_agent)])
     mock_model.chat = mocker.MagicMock(return_value=plan)
 
     agent = get_agent_for_task(task, scratchpad)
@@ -24,8 +26,9 @@ def test_get_agent_for_task_no_agent_found(mocker):
 
 def test_get_agent_for_task_agent_found(mocker):
     plan = {"agent_name": mock_agent_name}
-    mocker.patch("src.router.agents", mock_agents)
-    mocker.patch("src.router.llm", mock_model)
+    mocker.patch("src.router.get_llm", return_value=mock_model)
+    mocker.patch("src.router.get_question_agents", return_value=mock_agents)
+    mocker.patch("src.router.get_agent_details", return_value=[agent_details(mock_agent)])
     mock_model.chat = mocker.MagicMock(return_value=json.dumps(plan))
 
     agent = get_agent_for_task(task, scratchpad)

--- a/backend/tests/router_test.py
+++ b/backend/tests/router_test.py
@@ -1,11 +1,11 @@
 import json
+from src.llm import MockLLM
 from src.agents import agent_details
-from src.llm import get_llm
 from tests.agents import MockAgent, mock_agent_name
 from src.router import get_agent_for_task
 
 
-mock_model = get_llm("mockllm")
+mock_model = MockLLM()
 mock_agent = MockAgent("mockllm")
 mock_agents = [mock_agent]
 task = {"summary": "task1"}
@@ -15,7 +15,7 @@ scratchpad = []
 def test_get_agent_for_task_no_agent_found(mocker):
     plan = '{ "agent_name": "this_agent_does_not_exist" }'
     mocker.patch("src.router.get_llm", return_value=mock_model)
-    mocker.patch("src.router.get_question_agents", return_value=mock_agents)
+    mocker.patch("src.router.get_available_agents", return_value=mock_agents)
     mocker.patch("src.router.get_agent_details", return_value=[agent_details(mock_agent)])
     mock_model.chat = mocker.MagicMock(return_value=plan)
 
@@ -27,7 +27,7 @@ def test_get_agent_for_task_no_agent_found(mocker):
 def test_get_agent_for_task_agent_found(mocker):
     plan = {"agent_name": mock_agent_name}
     mocker.patch("src.router.get_llm", return_value=mock_model)
-    mocker.patch("src.router.get_question_agents", return_value=mock_agents)
+    mocker.patch("src.router.get_available_agents", return_value=mock_agents)
     mocker.patch("src.router.get_agent_details", return_value=[agent_details(mock_agent)])
     mock_model.chat = mocker.MagicMock(return_value=json.dumps(plan))
 

--- a/backend/tests/supervisors/supervisor_test.py
+++ b/backend/tests/supervisors/supervisor_test.py
@@ -1,5 +1,4 @@
 import pytest
-from src.llm import get_llm
 from src.utils import get_scratchpad
 from tests.agents import MockAgent
 from src.supervisors import solve_all, solve_task, no_questions_response, unsolvable_response, no_agent_response
@@ -25,7 +24,6 @@ intent_json = {
     ],
 }
 
-model = get_llm("mockllm")
 agent = MockAgent("mockllm")
 
 


### PR DESCRIPTION
## Description

This PR removes the dependency that our tests have on the .env file. This arose from certain imports causing files to run that were making use of env variables. My understanding is that this is a compile time issue. So, the change has been to make sure that wherever the env variables are used, it is at run time, and not compile time. For example, using getters for the agents instead of instantiating them in the __init__ file.

## Changelog
- Decouple unit test dependency to .env file
- Delete creation of .env file in ci
