### PR TITLE
Rewrite Connection Manager to Handle Multiple Connections

### DIFF
--- a/backend/src/api/app.py
+++ b/backend/src/api/app.py
@@ -11,7 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.utils.graph_db_utils import populate_db
 from src.utils import Config, test_connection
 from src.director import question
-from .connection_manager import ConnectionManager
+from .connection_manager import connection_manager, parse_message
 from src.utils.annual_cypher_import import annual_transactions_cypher_script
 
 config_file_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "config.ini"))
@@ -89,9 +89,13 @@ async def chat(utterance: str):
         return JSONResponse(status_code=500, content=chat_fail_response)
 
 
-connection_manager = ConnectionManager()
-
-
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket) -> NoReturn:
     await connection_manager.connect(websocket)
+    try:
+        while True:
+            message = await websocket.receive_json()
+            parsed_message = parse_message(message)
+            await connection_manager.handle_message(websocket, parsed_message)
+    except Exception:
+        await connection_manager.disconnect(websocket)

--- a/backend/src/api/connection_manager.py
+++ b/backend/src/api/connection_manager.py
@@ -1,5 +1,6 @@
+import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 from fastapi import WebSocket
 from fastapi.websockets import WebSocketState
 
@@ -14,42 +15,35 @@ def parse_message(message: Dict[str, Any]) -> Message:
 
 
 class ConnectionManager:
-    websocket: WebSocket | None
+    websockets: List[WebSocket]
 
     def __init__(self):
-        self.websocket = None
+        self.websockets = []
 
-    async def __handle_message(self, message: Message):
+    async def connect(self, ws: WebSocket):
+        if ws not in self.websockets:
+            await ws.accept()
+            self.websockets.append(ws)
+        else:
+            raise Exception(f"Given websocket ({ws}) was already being tracked")
+
+    async def disconnect(self, ws: WebSocket):
+        try:
+            self.websockets.remove(ws)
+            if ws.client_state != WebSocketState.DISCONNECTED:
+                await ws.close()
+        except ValueError:
+            pass
+
+    async def handle_message(self, ws: WebSocket, message: Message):
         handler = handlers.get(MessageTypes(message.type))
         if handler is None:
             raise Exception("No handler for message type")
+        handler(ws, self.disconnect, message.data)
 
-        if self.websocket is not None:
-            handler(self.websocket, self.disconnect, message.data)
+    async def broadcast(self, message: Message):
+        for ws in self.websockets:
+            if ws.application_state == WebSocketState.CONNECTED:
+                await ws.send_json(json.dumps({"type": message.type.value, "data": message.data}))
 
-    async def __on_message(self):
-        if self.websocket is None:
-            raise Exception("No connection")
-
-        raw_message = await self.websocket.receive_json()
-        parsed_message = parse_message(raw_message)
-
-        await self.__handle_message(parsed_message)
-        await self.__on_message()
-
-    async def connect(self, websocket: WebSocket):
-        if self.websocket is not None:
-            raise Exception("Connection already exists")
-
-        await websocket.accept()
-        self.websocket = websocket
-        try:
-            await self.__on_message()
-        except Exception as e:
-            logger.exception(f"Error in websocket process: {e}")
-            await self.disconnect()
-
-    async def disconnect(self):
-        if self.websocket is not None and self.websocket.client_state != WebSocketState.DISCONNECTED:
-            await self.websocket.close()
-        self.websocket = None
+connection_manager = ConnectionManager()

--- a/backend/src/api/connection_manager.py
+++ b/backend/src/api/connection_manager.py
@@ -41,6 +41,8 @@ class ConnectionManager:
             raise Exception("No handler for message type")
         handler(ws, self.disconnect, message.data)
 
+    # This broadcast method is a place holder until the backend has implemented the idea of a user session
+    # at that point this should be replaced by a send message that targets a specific web socket.
     async def broadcast(self, message: Message):
         for ws in self.websockets:
             if ws.application_state == WebSocketState.CONNECTED:

--- a/backend/src/api/message_handlers.py
+++ b/backend/src/api/message_handlers.py
@@ -14,10 +14,10 @@ pong = json.dumps({"type": MessageTypes.PONG.value})
 def create_on_ping():
     heartbeat_timer: asyncio.Task | None = None
 
-    async def heartbeat(disconnect: Callable):
+    async def heartbeat(disconnect: Callable, ws: WebSocket):
         try:
             await asyncio.sleep(heartbeat_timeout)
-            await disconnect()
+            await disconnect(ws)
         except asyncio.CancelledError:
             pass
 
@@ -29,7 +29,7 @@ def create_on_ping():
         if heartbeat_timer is not None:
             heartbeat_timer.cancel()
 
-        heartbeat_timer = asyncio.create_task(heartbeat(disconnect))
+        heartbeat_timer = asyncio.create_task(heartbeat(disconnect, websocket))
 
     return on_ping
 

--- a/backend/tests/api/connection_manager_test.py
+++ b/backend/tests/api/connection_manager_test.py
@@ -1,5 +1,9 @@
+import json
+from unittest.mock import patch
 import pytest
 from fastapi.websockets import WebSocketState
+from src.api.types import Message, MessageTypes
+from src.api.message_handlers import handlers
 from src.api.connection_manager import ConnectionManager
 
 error_message = "Test Error"
@@ -14,8 +18,8 @@ def connection_manager(mocker):
     manager = ConnectionManager()
     mock_ws = mocker.AsyncMock()
     mock_ws.accept = mocker.AsyncMock()
+    mock_ws.send_json = mocker.AsyncMock()
     mock_on_message = mocker.AsyncMock
-    mocker.patch.object(manager, "_ConnectionManager__on_message", new_callable=mock_on_message)
 
     return manager, mock_ws, mock_on_message
 
@@ -26,19 +30,32 @@ async def test_connect_new_websocket(connection_manager):
 
     await manager.connect(mock_ws)
 
-    assert manager.websocket == mock_ws
+    assert len(manager.websockets) == 1
+    assert manager.websockets[0] == mock_ws
     mock_ws.accept.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_connect_websocket_exists(mocker):
-    connection_manager = ConnectionManager()
-    connection_manager.websocket = mocker.AsyncMock()
+async def test_connect_second_websocket(connection_manager, mocker):
+    manager, mock_ws, _ = connection_manager
+    manager.websockets.append(mocker.AsyncMock())
+
+    await manager.connect(mock_ws)
+
+    assert len(manager.websockets) == 2
+    assert manager.websockets[1] == mock_ws
+    mock_ws.accept.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_websocket_already_in_manager(connection_manager):
+    manager, mock_ws, _ = connection_manager
+    manager.websockets.append(mock_ws)
 
     with pytest.raises(Exception) as error:
-        await connection_manager.connect(mocker.AsyncMock())
+        await manager.connect(mock_ws)
 
-    assert str(error.value) == "Connection already exists"
+    assert str(error.value) == f"Given websocket ({mock_ws}) was already being tracked"
 
 
 @pytest.mark.asyncio
@@ -57,28 +74,86 @@ async def test_disconnect_websocket_close_connection(connection_manager):
     manager, mock_ws, _ = connection_manager
     await manager.connect(mock_ws)
 
-    await manager.disconnect()
+    await manager.disconnect(mock_ws)
 
     mock_ws.close.assert_awaited_once()
-    assert manager.websocket is None
+    assert len(manager.websockets) == 0
 
 
 @pytest.mark.asyncio
-async def test_disconnect_websocket_no_websocket(connection_manager):
+async def test_disconnect_websocket_websocket_not_tracked(connection_manager):
     manager, mock_ws, _ = connection_manager
 
-    await manager.disconnect()
+    await manager.disconnect(mock_ws)
 
     mock_ws.close.assert_not_called()
-    assert manager.websocket is None
+    assert len(manager.websockets) == 0
 
 
 @pytest.mark.asyncio
 async def test_disconnect_websocket_already_disconnected(connection_manager):
     manager, mock_ws, _ = connection_manager
     mock_ws.client_state = WebSocketState.DISCONNECTED
+    manager.websockets.append(mock_ws)
 
-    await manager.disconnect()
+    await manager.disconnect(mock_ws)
 
     mock_ws.close.assert_not_called()
-    assert manager.websocket is None
+    assert len(manager.websockets) == 0
+
+@pytest.mark.asyncio
+async def test_handle_message_handler_exists_for_message_type_handler_called(connection_manager, mocker):
+    manager, mock_ws, _ = connection_manager
+    handler = mocker.Mock()
+    with patch.dict(handlers, {MessageTypes.CHAT: handler}):
+        message = Message(MessageTypes.CHAT, "Test String")
+
+        await manager.handle_message(mock_ws, message)
+
+        handler.assert_called()
+
+
+
+@pytest.mark.asyncio
+async def test_handle_message_handler_does_not_exist_for_message_type_handler_called(connection_manager):
+    manager, mock_ws, _ = connection_manager
+    with patch.dict(handlers, {}):
+        message = Message(MessageTypes.PONG, "Test String")
+
+        with pytest.raises(Exception) as error:
+            await manager.handle_message(mock_ws, message)
+
+        assert str(error.value) == "No handler for message type"
+
+
+
+@pytest.mark.asyncio
+async def test_broadcast_given_message_broadcasted(connection_manager):
+    manager, mock_ws, _ = connection_manager
+    manager.websockets.append(mock_ws)
+    mock_ws.application_state = WebSocketState.CONNECTED
+    message = Message(MessageTypes.CHAT, "Test String")
+
+    await manager.broadcast(message)
+
+    mock_ws.send_json.assert_awaited_once_with(json.dumps({"type": message.type.value, "data": message.data}))
+
+
+@pytest.mark.asyncio
+async def test_broadcast_given_ws_state_not_connected_message_not_broadcasted(connection_manager):
+    manager, mock_ws, _ = connection_manager
+    manager.websockets.append(mock_ws)
+    mock_ws.application_state = WebSocketState.CONNECTING
+    message = Message(MessageTypes.CHAT, "Test String")
+
+    await manager.broadcast(message)
+
+    mock_ws.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_no_ws_tracked_broadcast_does_not_throw(connection_manager):
+    manager, _, _ = connection_manager
+    message = Message(MessageTypes.CHAT, "Test String")
+
+    await manager.broadcast(message)


### PR DESCRIPTION
## Description
This PR just handles the changes made to the existing web socket code. The previous implementation made it very difficult to send data on the web socket unless it was in response to a message received. The new implementation starts to handle the idea of having multiple connections active at one time, but will require more work to be done on the implementation of user sessions.

## Changelog
- Reworks connection manager to handle multiple web sockets
- Adds new broadcast method to send Messages from the backend on the web socket
- Removes on_message method and recreates functionality in app.py
    - Functionality changed from using recursion to a while loop as long running connections could cause a recursion depth exceeded exception
- Rewrites unit tests to better cover new structure
