### PR TITLE
Feature/fix chart generator agent tests

### DIFF
--- a/backend/tests/agents/chart_generator_agent_test.py
+++ b/backend/tests/agents/chart_generator_agent_test.py
@@ -1,61 +1,93 @@
 from io import BytesIO
-import unittest
 from unittest.mock import patch, AsyncMock, MagicMock
 import pytest
 from src.agents.chart_generator_agent import generate_chart
+import base64
+import matplotlib.pyplot as plt
+from PIL import Image
+import json
 
+@pytest.mark.asyncio
+@patch("src.agents.chart_generator_agent.engine.load_prompt")
+@patch("src.agents.chart_generator_agent.sanitise_script", new_callable=MagicMock)
+async def test_generate_code_success(mock_sanitise_script, mock_load_prompt):
+    llm = AsyncMock()
+    model = "mock_model"
 
-class TestGenerateChartAgent(unittest.TestCase):
-    def setUp(self):
-        self.llm = AsyncMock()
-        self.model = "mock_model"
-        self.details_to_generate_chart_code = "details to generate chart code"
-        self.generate_chart_code_prompt = "generate chart code prompt"
+    mock_load_prompt.side_effect = [
+        "details to create chart code prompt",
+        "generate chart code prompt"
+    ]
 
-    @pytest.mark.asyncio
-    @patch("src.agents.chart_generator_agent.engine.load_prompt")
-    @patch("src.agents.chart_generator_agent.sanitise_script")
-    async def test_generate_code_success(self, mock_sanitise_script, mock_load_prompt):
-        mock_load_prompt.side_effect = [self.details_to_generate_chart_code, self.generate_chart_code_prompt]
-        self.llm.chat.return_value = "generated code"
-        mock_sanitise_script.return_value = """
+    llm.chat.return_value = "generated code"
 
+    mock_sanitise_script.return_value = """
 import matplotlib.pyplot as plt
 fig = plt.figure()
 plt.plot([1, 2, 3], [4, 5, 6])
-
 """
+    plt.switch_backend('Agg')
 
-        with patch("matplotlib.pyplot.figure") as mock_fig:
-            mock_fig_instance = MagicMock()
-            mock_fig.return_value = mock_fig_instance
-            result = await generate_chart("question_intent", "data_provided", "question_params", self.llm, self.model)
-            buf = BytesIO()
-            mock_fig_instance.savefig.assert_called_once_with(buf, format="png")
+    def mock_exec_side_effect(script, globals=None, locals=None):
+        if isinstance(script, str):
+            fig = plt.figure()
+            plt.plot([1, 2, 3], [4, 5, 6])
+            if locals is None:
+                locals = {}
+            locals['fig'] = fig
 
-        self.llm.chat.assert_called_once_with(
-            self.model, self.generate_chart_code_prompt, self.details_to_generate_chart_code
+    with patch("builtins.exec", side_effect=mock_exec_side_effect):
+        result = await generate_chart("question_intent", "data_provided", "question_params", llm, model)
+
+        response = json.loads(result)
+
+        image_data = response["content"]
+        decoded_image = base64.b64decode(image_data)
+
+        image = Image.open(BytesIO(decoded_image))
+        image.verify()
+
+        llm.chat.assert_called_once_with(
+            model,
+            "generate chart code prompt",
+            "details to create chart code prompt"
         )
         mock_sanitise_script.assert_called_once_with("generated code")
-        self.assertIsInstance(result, str)
 
-    @pytest.mark.asyncio
-    @patch("src.agents.chart_generator_agent.engine.load_prompt")
-    @patch("src.agents.chart_generator_agent.sanitise_script")
-    async def test_generate_code_no_figure(self, mock_sanitise_script, mock_load_prompt):
-        mock_load_prompt.side_effect = [self.details_to_generate_chart_code, self.generate_chart_code_prompt]
-        self.llm.chat.return_value = "generated code"
-        mock_sanitise_script.return_value = """
+@pytest.mark.asyncio
+@patch("src.agents.chart_generator_agent.engine.load_prompt")
+@patch("src.agents.chart_generator_agent.sanitise_script", new_callable=MagicMock)
+async def test_generate_code_no_figure(mock_sanitise_script, mock_load_prompt):
+    llm = AsyncMock()
+    model = "mock_model"
 
+    mock_load_prompt.side_effect = [
+        "details to create chart code prompt",
+        "generate chart code prompt"
+    ]
+
+    llm.chat.return_value = "generated code"
+
+    mock_sanitise_script.return_value = """
 import matplotlib.pyplot as plt
-# No figure is created
-
+# No fig creation
 """
 
-        with self.assertRaises(ValueError) as context:
-            await generate_chart("question_intent", "data_provided", "question_params", self.llm, self.model)
-        self.assertEqual(str(context.exception), "The generated code did not produce a figure named 'fig'.")
+    plt.switch_backend('Agg')
 
+    def mock_exec_side_effect(script, globals=None, locals=None):
+        if isinstance(script, str):
+            if locals is None:
+                locals = {}
 
-if __name__ == "__main__":
-    unittest.main()
+    with patch("builtins.exec", side_effect=mock_exec_side_effect):
+        with pytest.raises(ValueError, match="The generated code did not produce a figure named 'fig'."):
+            await generate_chart("question_intent", "data_provided", "question_params", llm, model)
+
+        llm.chat.assert_called_once_with(
+            model,
+            "generate chart code prompt",
+            "details to create chart code prompt"
+        )
+
+        mock_sanitise_script.assert_called_once_with("generated code")

--- a/backend/tests/agents/web_agent_test.py
+++ b/backend/tests/agents/web_agent_test.py
@@ -23,7 +23,7 @@ async def test_web_general_search_core(
     mock_is_valid_answer.return_value = True
     result = await web_general_search_core("example query", llm, model)
     expected_response = {
-        "content": "Example salut.",
+        "content": "Example summary.",
         "ignore_validation": "false"
     }
     assert json.loads(result) == expected_response

--- a/backend/tests/agents/web_agent_test.py
+++ b/backend/tests/agents/web_agent_test.py
@@ -1,8 +1,6 @@
-import unittest
-from unittest.mock import AsyncMock, patch
-import json
-
 import pytest
+from unittest.mock import patch, AsyncMock
+import json
 from src.agents.web_agent import web_general_search_core
 
 @pytest.mark.asyncio
@@ -25,7 +23,7 @@ async def test_web_general_search_core(
     mock_is_valid_answer.return_value = True
     result = await web_general_search_core("example query", llm, model)
     expected_response = {
-        "content": "Example summary.",
+        "content": "Example salut.",
         "ignore_validation": "false"
     }
     assert json.loads(result) == expected_response

--- a/backend/tests/agents/web_agent_test.py
+++ b/backend/tests/agents/web_agent_test.py
@@ -1,76 +1,69 @@
 import unittest
 from unittest.mock import AsyncMock, patch
+import json
 
 import pytest
 from src.agents.web_agent import web_general_search_core
 
+@pytest.mark.asyncio
+@patch("src.agents.web_agent.perform_search", new_callable=AsyncMock)
+@patch("src.agents.web_agent.perform_scrape", new_callable=AsyncMock)
+@patch("src.agents.web_agent.perform_summarization", new_callable=AsyncMock)
+@patch("src.agents.web_agent.is_valid_answer", new_callable=AsyncMock)
+async def test_web_general_search_core(
+    mock_is_valid_answer,
+    mock_perform_summarization,
+    mock_perform_scrape,
+    mock_perform_search,
+):
+    llm = AsyncMock()
+    model = "mock_model"
 
-class TestWebAgentCore(unittest.TestCase):
-    def setUp(self):
-        self.llm = AsyncMock()
-        self.model = "mock_model"
+    mock_perform_search.return_value = {"status": "success", "urls": ["http://example.com"]}
+    mock_perform_scrape.return_value = "Example scraped content."
+    mock_perform_summarization.return_value = "Example summary."
+    mock_is_valid_answer.return_value = True
+    result = await web_general_search_core("example query", llm, model)
+    expected_response = {
+        "content": "Example summary.",
+        "ignore_validation": "false"
+    }
+    assert json.loads(result) == expected_response
 
-    @patch("src.agents.web_agent.perform_search")
-    @patch("src.agents.web_agent.perform_scrape")
-    @patch("src.agents.web_agent.perform_summarization")
-    @patch("src.agents.web_agent.is_valid_answer")
-    @pytest.mark.asyncio
-    async def test_web_general_search_core(
-        self, mock_is_valid_answer, mock_perform_summarization, mock_perform_scrape, mock_perform_search
-    ):
-        mock_perform_search.return_value = {"status": "success", "urls": ["http://example.com"]}
-        mock_perform_scrape.return_value = "Example scraped content."
-        mock_perform_summarization.return_value = "Example summary."
-        mock_is_valid_answer.return_value = True
-
-        result = await web_general_search_core("example query", self.llm, self.model)
-        self.assertEqual(result, "Example summary.")
-        mock_perform_search.assert_called_once_with("example query", num_results=15)
-        mock_perform_scrape.assert_called_once_with("http://example.com")
-        mock_perform_summarization.assert_called_once_with(
-            "example query", "Example scraped content.", self.llm, self.model
-        )
-        mock_is_valid_answer.assert_called_once_with("Example summary.", "example query")
-
-    @patch("src.agents.web_agent.perform_search")
-    @patch("src.agents.web_agent.perform_scrape")
-    @patch("src.agents.web_agent.perform_summarization")
-    @patch("src.agents.web_agent.is_valid_answer")
-    @pytest.mark.asyncio
-    async def test_web_general_search_core_no_results(
-        self, mock_is_valid_answer, mock_perform_summarization, mock_perform_scrape, mock_perform_search
-    ):
-        mock_perform_search.return_value = {"status": "error", "urls": []}
-
-        result = await web_general_search_core("example query", self.llm, self.model)
-        self.assertEqual(result, "No relevant information found on the internet for the given query.")
-        mock_perform_search.assert_called_once_with("example query", num_results=15)
-        mock_perform_scrape.assert_not_called()
-        mock_perform_summarization.assert_not_called()
-        mock_is_valid_answer.assert_not_called()
-
-    @patch("src.agents.web_agent.perform_search")
-    @patch("src.agents.web_agent.perform_scrape")
-    @patch("src.agents.web_agent.perform_summarization")
-    @patch("src.agents.web_agent.is_valid_answer")
-    @pytest.mark.asyncio
-    async def test_web_general_search_core_invalid_summary(
-        self, mock_is_valid_answer, mock_perform_summarization, mock_perform_scrape, mock_perform_search
-    ):
-        mock_perform_search.return_value = {"status": "success", "urls": ["http://example.com"]}
-        mock_perform_scrape.return_value = "Example scraped content."
-        mock_perform_summarization.return_value = "Example invalid summary."
-        mock_is_valid_answer.return_value = False
-
-        result = await web_general_search_core("example query", self.llm, self.model)
-        self.assertEqual(result, "No relevant information found on the internet for the given query.")
-        mock_perform_search.assert_called_once_with("example query", num_results=15)
-        mock_perform_scrape.assert_called_once_with("http://example.com")
-        mock_perform_summarization.assert_called_once_with(
-            "example query", "Example scraped content.", self.llm, self.model
-        )
-        mock_is_valid_answer.assert_called_once_with("Example invalid summary.", "example query")
+@pytest.mark.asyncio
+@patch("src.agents.web_agent.perform_search", new_callable=AsyncMock)
+@patch("src.agents.web_agent.perform_scrape", new_callable=AsyncMock)
+@patch("src.agents.web_agent.perform_summarization", new_callable=AsyncMock)
+@patch("src.agents.web_agent.is_valid_answer", new_callable=AsyncMock)
+async def test_web_general_search_core_no_results(
+    mock_is_valid_answer,
+    mock_perform_summarization,
+    mock_perform_scrape,
+    mock_perform_search,
+):
+    llm = AsyncMock()
+    model = "mock_model"
+    mock_perform_search.return_value = {"status": "error", "urls": []}
+    result = await web_general_search_core("example query", llm, model)
+    assert result == "No relevant information found on the internet for the given query."
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.asyncio
+@patch("src.agents.web_agent.perform_search", new_callable=AsyncMock)
+@patch("src.agents.web_agent.perform_scrape", new_callable=AsyncMock)
+@patch("src.agents.web_agent.perform_summarization", new_callable=AsyncMock)
+@patch("src.agents.web_agent.is_valid_answer", new_callable=AsyncMock)
+async def test_web_general_search_core_invalid_summary(
+    mock_is_valid_answer,
+    mock_perform_summarization,
+    mock_perform_scrape,
+    mock_perform_search
+):
+    llm = AsyncMock()
+    model = "mock_model"
+    mock_perform_search.return_value = {"status": "success", "urls": ["http://example.com"]}
+    mock_perform_scrape.return_value = "Example scraped content."
+    mock_perform_summarization.return_value = "Example invalid summary."
+    mock_is_valid_answer.return_value = False
+    result = await web_general_search_core("example query", llm, model)
+    assert result == "No relevant information found on the internet for the given query."


### PR DESCRIPTION
## Description
This PR moves the Chart Generator Agent tests away from unitttest as previously all tests were passing whatever the values (the method was not being awaited)

## Changelog
- Chart Generator Agent tests
- Please ignore changes made to web agent tests, this was due to a local issue
